### PR TITLE
Issue on WordPress plugin reactivation (after upgrade)

### DIFF
--- a/trunk/gravity-forms-addons.php
+++ b/trunk/gravity-forms-addons.php
@@ -4,7 +4,7 @@ Plugin Name: Gravity Forms Directory & Addons
 Plugin URI: http://katz.co/gravity-forms-addons/
 Description: Turn <a href="http://katz.si/gravityforms" rel="nofollow">Gravity Forms</a> into a great WordPress directory...and more!
 Author: Katz Web Services, Inc.
-Version: 3.5.4
+Version: 3.5.4.1
 Author URI: http://www.katzwebservices.com
 
 Copyright 2014 Katz Web Services, Inc.  (email: info@katzwebservices.com)

--- a/trunk/gravity-forms-lead-creator.php
+++ b/trunk/gravity-forms-lead-creator.php
@@ -4,7 +4,7 @@ Plugin Name: Gravity Forms Change Entry Creator Add-on
 Plugin URI: http://katz.co/gravity-forms-addons/
 Description: This simple addon allows users with Entry-editing capabilities to change who a <a href="http://katz.si/gravityforms" rel="nofollow">Gravity Forms</a> lead is assigned to.
 Author: Katz Web Services, Inc.
-Version: 3.5.4
+Version: 3.5.4.1
 Author URI: http://www.katzwebservices.com
 
 Copyright 2014 Katz Web Services, Inc. (email: info@katzwebservices.com)


### PR DESCRIPTION
rename filename from change-lead-creator.php to gravity-forms-lead-creator.php as WordPress activates the first file with plugin info encountered in the directory (ordered by name) - this way, the main file gravity-forms-addons.php will appear first.
