### PR TITLE
Dont escape_html()

### DIFF
--- a/template-row.php
+++ b/template-row.php
@@ -133,7 +133,6 @@
 								if(in_array('images', $lightboxsettings) || !empty($lightboxsettings['images'])) {
 									$lightboxclass .= ' rel="directory_all directory_images"';
 								}
-								$value = "<a href='{$url}'{$target}{$lightboxclass}>{$img['code']}</a>";
 							}
 						break;
 


### PR DESCRIPTION
As you can [see](http://prntscr.com/556sg8) we are getting a lot of mixed HTML from your last update. This patch fixes it (but also removes the cool image icon). But, it is at least usable at this point.

Gravity Forms Version: 1.8.15
WordPress: 4.0
