### PR TITLE
Resolve directory columns issue

### DIFF
--- a/edit-form.php
+++ b/edit-form.php
@@ -10,7 +10,7 @@ class GFDirectory_EditForm {
 
 	function __construct() {
 
-		add_action('admin_init',  array(&$this, 'process_exterior_pages'));
+		add_action('admin_init',  array(&$this, 'process_exterior_pages'), 9 );
 
 		if(self::is_gravity_page() ) {
 

--- a/gravity-forms-addons.php
+++ b/gravity-forms-addons.php
@@ -1270,7 +1270,7 @@ class GFDirectory {
 		}
 
 		ob_start(); // Using ob_start() allows us to use echo instead of $output .=
-
+		$atts = (array) $atts; // Type casting $atts to array to work if empty.
 		foreach ( $atts as $key => $att ) {
 			if ( strtolower( $att ) == 'false' ) {
 				$atts[ $key ] = false;


### PR DESCRIPTION
Issue - https://wordpress.org/support/topic/gravity-directory-column-editor-not-working/

Found that the function GFForms::process_exterior_pages() in Gravity Forms plugin was executing exit() before the function GFDirectory_EditForm::process_exterior_pages written in Gravity forms directory plugin code.

Changed action priority so that the process_exterior_pages written in directory plugin executes first.